### PR TITLE
Fixed issue where the 'Remove all copied files' link would appear outside of edit mode

### DIFF
--- a/Google chrome extension/content.js
+++ b/Google chrome extension/content.js
@@ -24,7 +24,7 @@ $(document).ready(function() {
         };
 
         //if already in edit mode, add the modification items
-        if($("div.edit-mode-help").length > 0){
+        if($("div.edit-mode-help:visible").length > 0){
             appendAllModificationItems();
         }
 

--- a/Safari extension/FisheyeDirectoryRemover.safariextension/content.js
+++ b/Safari extension/FisheyeDirectoryRemover.safariextension/content.js
@@ -24,7 +24,7 @@ $(document).ready(function() {
         };
 
         //if already in edit mode, add the modification items
-        if($("div.edit-mode-help").length > 0){
+        if($("div.edit-mode-help:visible").length > 0){
             appendAllModificationItems();
         }
 


### PR DESCRIPTION
Found and fixed issue where "Remove all copied files" would appear upon loading a code review if the user was not editing. Corrected by adding the visible selector to the appropriate jquery selector.